### PR TITLE
Adding a widget to show code cells in a scene and collapse the others

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["jupyter_packaging~=0.10,<2", "jupyterlab~=3.1"]
+requires = ["jupyter_packaging~=0.10,<2", "jupyterlab>=3.1"]
 build-backend = "jupyter_packaging.build_api"
 
 [tool.jupyter-packaging.options]

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -160,9 +160,6 @@ export class NotebookHandler {
 
         const set_membership = !this._nbTracker.activeCell.model.getMetadata(tag);
 
-        //const set_membership = !this._nbTracker.activeCell.model.getMetadata(tag);
-
-        
 
         notebook.widgets.forEach((cell: Cell) => {
             if(!notebook.isSelectedOrActive(cell)) return;
@@ -234,7 +231,30 @@ export class NotebookHandler {
         this._moveScene(this._sceneDB.getActiveScene()!, 'down');
         this._scenesChanged();
     }
-    
+
+    showActiveSceneInCurrentNotebook() {
+        const active_scene = this._sceneDB.getActiveScene();
+        if(active_scene) this.showSceneInCurrentNotebook(active_scene);
+    }
+    showSceneInCurrentNotebook(scene_name: string) {
+        if(!this._nbTracker.currentWidget) return;
+        const notebook = this._nbTracker.currentWidget.content;
+        if (!notebook.model || !notebook.activeCell) return;
+        const tag = this._getSceneTag(scene_name);
+
+        notebook.widgets.forEach(cell => {
+            if (cell.model.type === 'code') {
+                if(!!cell.model.getMetadata(tag)) {
+                    cell.inputHidden = false;
+                    (cell as CodeCell).outputHidden = false;
+                } else {
+                    cell.inputHidden = true;
+                    (cell as CodeCell).outputHidden = true;
+                }
+            }
+        });
+    }
+
     // **** various **************************************************************
 
     updateCellClassesAndTags(notebook: Notebook, scene_name:(string|null)=null, cell:(Cell|null)=null) {

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -1,7 +1,7 @@
 import { CommandRegistry } from '@lumino/commands';
 import * as React from 'react';
 import { NotebookHandler } from './backend';
-import { runIcon, closeIcon, editIcon, addIcon, copyIcon } from '@jupyterlab/ui-components';
+import { runIcon, closeIcon, editIcon, addIcon, copyIcon, treeViewIcon } from '@jupyterlab/ui-components';
 import { LabIcon } from '@jupyterlab/ui-components'
 
 
@@ -89,6 +89,12 @@ class ScenesList extends React.Component<IPropertiesScenesList, IState> {
                 event.stopPropagation();
                 this.props.notebookHandler.runSceneInCurrentNotebook(scene_name);
             }
+
+            const onClickShow = (event: React.SyntheticEvent<HTMLSpanElement>) => {
+                event.preventDefault();
+                event.stopPropagation();
+                this.props.notebookHandler.showSceneInCurrentNotebook(scene_name);
+            }
             
             let active = this.props.currentScene == scene_name;
             let init = this.props.initScene == scene_name;
@@ -101,6 +107,7 @@ class ScenesList extends React.Component<IPropertiesScenesList, IState> {
                     <button className="scenes-ItemButton" title="Delete Scene" onClick={onClickDelete}><closeIcon.react tag="span" className="jp-ToolbarButtonComponent-icon f1vya9e0"/></button>
                     <button className="scenes-ItemButton" title="Run Scene" onClick={onClickRun}><runIcon.react tag="span" className="jp-ToolbarButtonComponent-icon f1vya9e0"/></button>
                     <button className="scenes-ItemButton" title="Rename Scene" onClick={onClickEdit}><editIcon.react tag="span" className="jp-ToolbarButtonComponent-icon f1vya9e0"/></button>
+                    <button className="scenes-ItemButton" title="Show Scene" onClick={onClickShow}><treeViewIcon.react tag="span" className="jp-ToolbarButtonComponent-icon f1vya9e0"/></button>
                     <div className="scenes-ItemText">{sceneNameDisplay}</div>
                     <div className="scenes-SceneItemSpacer"></div>
                     <button onClick={onClickInit} className={classNameInitButton}>init</button>

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -104,10 +104,10 @@ class ScenesList extends React.Component<IPropertiesScenesList, IState> {
                         
             return (
                 <div className={className} onClick={onClickActivate} key={scene_name}>
-                    <button className="scenes-ItemButton" title="Delete Scene" onClick={onClickDelete}><closeIcon.react tag="span" className="jp-ToolbarButtonComponent-icon f1vya9e0"/></button>
                     <button className="scenes-ItemButton" title="Run Scene" onClick={onClickRun}><runIcon.react tag="span" className="jp-ToolbarButtonComponent-icon f1vya9e0"/></button>
-                    <button className="scenes-ItemButton" title="Rename Scene" onClick={onClickEdit}><editIcon.react tag="span" className="jp-ToolbarButtonComponent-icon f1vya9e0"/></button>
                     <button className="scenes-ItemButton" title="Show Scene" onClick={onClickShow}><treeViewIcon.react tag="span" className="jp-ToolbarButtonComponent-icon f1vya9e0"/></button>
+                    <button className="scenes-ItemButton" title="Rename Scene" onClick={onClickEdit}><editIcon.react tag="span" className="jp-ToolbarButtonComponent-icon f1vya9e0"/></button>
+                    <button className="scenes-ItemButton" title="Delete Scene" onClick={onClickDelete}><closeIcon.react tag="span" className="jp-ToolbarButtonComponent-icon f1vya9e0"/></button>
                     <div className="scenes-ItemText">{sceneNameDisplay}</div>
                     <div className="scenes-SceneItemSpacer"></div>
                     <button onClick={onClickInit} className={classNameInitButton}>init</button>

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ function activateScenes(app: JupyterFrontEnd, settingRegistry: ISettingRegistry,
 
   // create the ScenesSidebar widget
   const scenesSidebar = new ScenesSidebar(app, nbTracker, mainMenu, settingRegistry);
-  app.shell.add(scenesSidebar, 'left', { rank: 1000 });
+  app.shell.add(scenesSidebar, 'right', { rank: 1000 });
 }
 
 /**

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -182,6 +182,20 @@ export class ScenesSidebar extends ReactWidget {
             label: 'Jump to Previous Scene Cell',
             execute: () => { this._notebookHandler.jumpToPreviousSceneCell(); }
         });
+
+        this._app.commands.addCommand(ScenesSidebar.command_id_show_scene, {
+            label: 'Show Scene',
+            execute: (scene_name) => {
+                if(typeof scene_name == "string") {
+                    console.log('show', scene_name)
+                    this._notebookHandler.showSceneInCurrentNotebook(scene_name);
+                } else {
+                    console.log('show active')
+                    this._notebookHandler.showActiveSceneInCurrentNotebook();
+                }
+            }
+        });
+
     }
 
     private _setupKeyboardShortcuts() {
@@ -205,6 +219,7 @@ export class ScenesSidebar extends ReactWidget {
 
         this._scenesMenu.addItem({command: ScenesSidebar.command_id_toggle_scene_cell});
         this._scenesMenu.addItem({command: ScenesSidebar.command_id_run_scene});
+        this._scenesMenu.addItem({command: ScenesSidebar.command_id_show_scene});
         this._scenesMenu.addItem({type: 'separator'});
         this._scenesMenu.addItem({command: ScenesSidebar.command_id_new_empty_scene});
         this._scenesMenu.addItem({command: ScenesSidebar.command_id_duplicate_scene});
@@ -233,4 +248,5 @@ export class ScenesSidebar extends ReactWidget {
     static command_id_move_active_scene_down = 'scenes:move-active-scene-down';
     static command_id_to_next_scene_cell =     'scenes:jump-to-next-scene-cell';
     static command_id_to_previous_scene_cell = 'scenes:jump-to-previous-scene-cell';
+    static command_id_show_scene =             'scenes:show-scene';
 };


### PR DESCRIPTION
Many thanks for this extension, it helped a lot!
I made some improvements to this extensions.
1. (major) A button to show code cells in a scene and collapse the others. It's very useful (at least for me) when one has many scenes. Using such a button, one can focus on the wanted scene.
2. (minor) Moving the sidebar to the right such that one can use "Table of Contents" and this extension simultaneously.
3. (minor) Rearranging the buttons in sidebar.